### PR TITLE
Fixed scene title prop type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ interface SceneProps extends React.Props<Scene> {
   rightButtonTextStyle?: StyleProp<TextStyle>;
   success?: (() => void) | string;
   tabs?: boolean;
-  title?: string;
+  title?: (() => string) | string;
   titleStyle?: StyleProp<TextStyle>;
   type?: ActionConstShort;
   [name: string]: any; // These are passed through to the scenes


### PR DESCRIPTION
The scene title prop accepts a string or a function as value, but the type is only string.
A function returning string type has been added to the scene title type.